### PR TITLE
Fix code scanning alert no. 2: Log Injection

### DIFF
--- a/src/main/java/cc/baka9/catseedlogin/bukkit/Communication.java
+++ b/src/main/java/cc/baka9/catseedlogin/bukkit/Communication.java
@@ -80,7 +80,8 @@ private static void handleRequest(Socket socket) {
                 handleKeepLoggedInRequest(playerName, time, sign);
                 break;
             default:
-                CatSeedLogin.instance.getLogger().warning("未知请求类型: " + requestType);
+                String sanitizedRequestType = requestType.replace("\n", "").replace("\r", "");
+                CatSeedLogin.instance.getLogger().warning("未知请求类型: " + sanitizedRequestType);
                 break;
         }
     } catch (IOException e) {


### PR DESCRIPTION
Fixes [https://github.com/zhinghu/CatSeedLogin/security/code-scanning/2](https://github.com/zhinghu/CatSeedLogin/security/code-scanning/2)

To fix the log injection issue, we need to sanitize the `requestType` before logging it. The best way to do this is to remove any potentially harmful characters, such as newlines, from the `requestType`. This can be done using the `replace` method to replace newline characters with an empty string. Additionally, we should ensure that the `requestType` is clearly marked in the log entry to prevent any confusion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
