### PR TITLE
Fix code scanning alert no. 4: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/src/main/java/cc/baka9/catseedlogin/util/CommunicationAuth.java
+++ b/src/main/java/cc/baka9/catseedlogin/util/CommunicationAuth.java
@@ -9,7 +9,7 @@ public class CommunicationAuth {
 
     static {
         try {
-            messageDigest = MessageDigest.getInstance("MD5");
+            messageDigest = MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Fixes [https://github.com/zhinghu/CatSeedLogin/security/code-scanning/4](https://github.com/zhinghu/CatSeedLogin/security/code-scanning/4)

To fix the problem, we should replace the use of the MD5 algorithm with a stronger, modern cryptographic algorithm. A good choice would be SHA-256, which is part of the SHA-2 family and is widely regarded as secure for most purposes.

- Replace `MessageDigest.getInstance("MD5")` with `MessageDigest.getInstance("SHA-256")`.
- Ensure that the rest of the code remains unchanged to maintain existing functionality.
- No additional imports are needed as `MessageDigest` already supports SHA-256.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
